### PR TITLE
fix: correct package name in lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@context-labs/docs",
+  "name": "@kuzco/docs",
   "version": "0.0.107",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@context-labs/docs",
+      "name": "@kuzco/docs",
       "version": "0.0.107",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
probably copied from somewhere else