### PR TITLE
Add Apple Silicon Recommendations and CLI Instructions

### DIFF
--- a/pages/hardware.mdx
+++ b/pages/hardware.mdx
@@ -12,8 +12,25 @@ Kuzco supports many different hardware configurations across Mac, Windows, and L
 - 30GB free disk space
 - Reliable 100Mbps+ network bandwidth. Test it here: [Fast.com](https://fast.com/)
 
+## Supported Apple Silicon Chips
+
+Kuzco supports a range of Apple Silicon chips, provided they meet the following minimum system requirements:
+
+- **16GB RAM**
+- **30GB free disk space**
+- **Reliable 100Mbps+ network bandwidth**
+
+| Chip Series | Variants                   | Notes                                                                 |
+|-------------|---------------------------|-----------------------------------------------------------------------|
+| M1          | M1, M1 Pro, M1 Max, M1 Ultra | Fully supported                                                       |
+| M2          | M2, M2 Pro, M2 Max, M2 Ultra | Fully supported                                                       |
+| M3          | M3, M3 Pro, M3 Max          | Fully supported (latest generation as of 2025)                        |
+| M4          | M4, M4 Pro, M4 Max          | Fully supported (latest generation released in 2024)                  |
+
 <Callout emoji="💡">
-  For MacOS users, any M-series chip with the above requirements will work.
+  For Mac users, we recommend launching your worker through the terminal using the CLI commands.  
+  Detailed instructions can be found here: [Kuzco CLI Documentation](https://docs.kuzco.xyz/kuzco-cli).  
+  Navigate to the "CLI" tab in the "Launch Worker" section of the [Kuzco Dashboard](https://kuzco.xyz/dashboard) for specific steps.
 </Callout>
 
 


### PR DESCRIPTION
This update improves the documentation for supported Apple Silicon chips by:
	•	Listing all current M-series processors (M1, M2, M3, M4, and their variants).
	•	Highlighting minimum system requirements for Apple Silicon.
	•	Recommending Mac users to launch workers via the CLI for better compatibility and performance.
	•	Adding a direct link to the [Kuzco CLI Documentation](https://docs.kuzco.xyz/kuzco-cli) for detailed setup instructions.

These additions aim to provide clarity and improve the onboarding experience for Mac users.