### PR TITLE
Fix grammar and title formatting in documentation

### DIFF
--- a/pages/_meta.json
+++ b/pages/_meta.json
@@ -8,5 +8,6 @@
   "discord-roles": "Discord Roles",
   "hardware": "Hardware",
   "support": "Support",
-  "metadata-api": "Metadata API"
+  "metadata-api": "Metadata API",
+  "faq": "FAQ"
 }

--- a/pages/faq.mdx
+++ b/pages/faq.mdx
@@ -11,5 +11,11 @@ Epoch Two is the second Epoch of the Kuzco network. It is started running in Dec
 ## Where are my Epoch One rewards?
 If you participated in Epoch One as a worker, you can view your Epoch One balance in the settings page of the Kuzco dashboard [here](https://inference.supply/dashboard/settings).
 
+## Should I rent GPUs?
+Kuzco is neutral on this topic. The majority of our users own the GPUs they use to run Kuzco.
+
 ## I'm getting an error about Duplicate GPUs
 We only allow one worker per logical GPU device. If you are getting this error while trying to start an instance, it is likely that an instance is already running on that GPU. If you are sure that no instance is running on that GPU, please open a ticket on the [Discord server](https://discord.gg/kuzco).
+
+## How do I get support?
+If you need help with Kuzco, please join the [Discord server](https://discord.gg/kuzco) and open a ticket in the `#support` channel.

--- a/pages/faq.mdx
+++ b/pages/faq.mdx
@@ -1,0 +1,15 @@
+import { Callout, Steps, Step, Image } from "nextra-theme-docs";
+
+# Kuzco FAQ
+
+## What is Epoch One?
+Epoch One was the first Epoch of the Kuzco network. It ran from March 2024 to November 2024. Workers were able to earn $KZO tokens by providing compute resources to the network.
+
+## What is Epoch Two?
+Epoch Two is the second Epoch of the Kuzco network. It is started running in December 2024. An end date has not been announced yet.
+
+## Where are my Epoch One rewards
+If you participated in Epoch One as a worker, you can view your Epoch One balance in the settings page of the Kuzco dashboard [here](https://inference.supply/dashboard/settings).
+
+## I'm geting an error about Duplicate GPUs
+We only allow one worker per logical GPU device. If you are getting this error while trying to start an instance, it is likely that an instance is already running on that GPU. If you are sure that no instance is running on that GPU, please open a ticket on the [Discord server](https://discord.gg/kuzco).

--- a/pages/faq.mdx
+++ b/pages/faq.mdx
@@ -8,8 +8,8 @@ Epoch One was the first Epoch of the Kuzco network. It ran from March 2024 to No
 ## What is Epoch Two?
 Epoch Two is the second Epoch of the Kuzco network. It is started running in December 2024. An end date has not been announced yet.
 
-## Where are my Epoch One rewards
+## Where are my Epoch One rewards?
 If you participated in Epoch One as a worker, you can view your Epoch One balance in the settings page of the Kuzco dashboard [here](https://inference.supply/dashboard/settings).
 
-## I'm geting an error about Duplicate GPUs
+## I'm getting an error about Duplicate GPUs
 We only allow one worker per logical GPU device. If you are getting this error while trying to start an instance, it is likely that an instance is already running on that GPU. If you are sure that no instance is running on that GPU, please open a ticket on the [Discord server](https://discord.gg/kuzco).

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -1,27 +1,22 @@
 import { Callout, Steps, Step } from "nextra-theme-docs";
 import { WIP } from "../components/WIP";
 
-# Overview
+# What is Kuzco Testnet?
 
-Kuzco is a distributed GPU cluster built on the Solana blockchain, designed to facilitate efficient and cost-effective inference of large language models (LLMs) such as Llama3, Mistral, Phi3, and more. By leveraging the power of idle compute resources contributed by network participants, Kuzco enables users to access these models through an OpenAI-compatible API.
+Kuzco Testnet is a globally distributed network of GPUs that are used to run AI inference tasks for large language models like Llama3, Mistral, and more. Anyone with a GPU that meets the [minimum requirements](/hardware) can join the network and start earning $KZO points. The more GPUs you connect, the more $KZO points you earn.
 
-<WIP />
+### What is a Kuzco Testnet Operator?
+An operator is a user who connects their GPUs to the Kuzco Testnet. Operators can earn $KZO points by contributing their compute power to the network. Operators are responsible maintaining their GPUs and ensuring they are running optimally.
 
-## Key Features
+### Is Kuzco Testnet stable?
+**Kuzco Testnet is currently in its early stages of development.** This means that the network is not yet stable and there will be bugs, and periods of downtime. When there is downtime, we will notify the community on our [Operator Discord](https://discord.gg/kuzco). We are actively working to improve the network, improve stability, and add more features. We are not yet ready for production use, but we are working hard to get there.
 
-- **Distributed GPU Cluster**: Kuzco harnesses the collective power of GPUs across the network, allowing for scalable and efficient LLM inference.
-- **Solana Integration**: Built on the Solana blockchain, Kuzco benefits from its high-performance, low-latency, and cost-effective infrastructure.
-- **Idle Compute Utilization**: Network participants can contribute their idle compute power and earn rewards for their contributions.
-- **OpenAI-Compatible API**: Kuzco provides an API that is compatible with OpenAI, making it easy for developers to integrate and utilize popular LLMs like Llama3 and Mistral.
-- **Cost-Effective**: By leveraging idle compute resources, Kuzco offers a cost-effective solution for LLM inference compared to traditional centralized approaches.
+### What should I do if there is downtime?
+Monitor the [announcements channel](https://discord.com/channels/1100110477599723550/1215659199846154261) in the Kuzco Discord for downtime updates from the Kuzco team. 
 
-{/* ## Getting Started
+### What should I do if I have a bug report?
+Please [open a ticket](https://discord.com/channels/1100110477599723550/1217137677363707925) in Discord if you have a bug report. Make sure to include all relevant information in order to help us fix the issue. If you do not, your ticket will be closed. Please avoid tagging the team directly outside of support channels. 
 
-To get started with Kuzco, follow these steps:
+### How can I get started?
 
-1. **Installation**: Install the necessary dependencies and set up your environment.
-2. **Network Participation**: Join the Kuzco network and configure your node to contribute idle compute power.
-3. **API Integration**: Integrate the Kuzco API into your application to access and utilize LLMs like Llama3, Mistral, Phi3, and more.
-4. **Inference**: Use the API to perform inference tasks and leverage the power of the distributed GPU cluster.
-
-For detailed instructions and code examples, refer to the respective sections of the documentation. */}
+Follow our [quick start guide](/quick-start) to install Kuzco and get started.

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -6,7 +6,7 @@ import { WIP } from "../components/WIP";
 Kuzco Testnet is a globally distributed network of GPUs that are used to run AI inference tasks for large language models like Llama3, Mistral, and more. Anyone with a GPU that meets the [minimum requirements](/hardware) can join the network and start earning $KZO points. The more GPUs you connect, the more $KZO points you earn.
 
 ### What is a Kuzco Testnet Operator?
-An operator is a user who connects their GPUs to the Kuzco Testnet. Operators can earn $KZO points by contributing their compute power to the network. Operators are responsible maintaining their GPUs and ensuring they are running optimally.
+An operator is a user who connects their GPUs to the Kuzco Testnet. Operators can earn $KZO points by contributing their compute power to the network. Operators are responsible for maintaining their GPUs and ensuring they are running optimally.
 
 ### Is Kuzco Testnet stable?
 **Kuzco Testnet is currently in its early stages of development.** This means that the network is not yet stable and there will be bugs, and periods of downtime. When there is downtime, we will notify the community on our [Operator Discord](https://discord.gg/kuzco). We are actively working to improve the network, improve stability, and add more features. We are not yet ready for production use, but we are working hard to get there.

--- a/pages/wsl-setup.mdx
+++ b/pages/wsl-setup.mdx
@@ -1,6 +1,6 @@
 import { Callout, Steps, Step } from "nextra-theme-docs";
 
-# Windows Linux Subsystem Setup
+# Windows Subsystem for Linux Setup
 
 This guide will take you through the steps to set up the Windows Subsystem for Linux (WSL), which allows you to run a Linux environment directly on Windows 10 or higher. This eliminates the need for a separate virtual machine or dual-boot setup.
 


### PR DESCRIPTION
This PR includes the following changes:

1. Added missing preposition "for" in the operator description:
   - Before: "Operators are responsible maintaining their GPUs"
   - After: "Operators are responsible for maintaining their GPUs"

2. Fixed Windows Subsystem for Linux title formatting:
   - Before: "# Windows Linux Subsystem Setup"
   - After: "# Windows Subsystem for Linux Setup"

These changes improve grammar and maintain consistency with official Microsoft terminology.